### PR TITLE
Rebased 9 bookit commits (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ create-foundation: upload
 		--parameters \
 			"ParameterKey=CidrBlock,ParameterValue=10.1.0.0/16" \
 			"ParameterKey=Environment,ParameterValue=${ENV}" \
-			"ParameterKey=FoundationBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.foundation" \
+			"ParameterKey=FoundationBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation" \
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomain,ParameterValue=${DOMAIN}" \
 			"ParameterKey=PublicFQDN,ParameterValue=${SUBDOMAIN}.${DOMAIN}" \
@@ -85,6 +85,7 @@ create-foundation: upload
 create-app: upload-app
 	@aws cloudformation create-stack --stack-name "${PROJECT}-${ENV}-${NAME_SUFFIX}-app-${APP}" \
 		--capabilities CAPABILITY_NAMED_IAM \
+		--disable-rollback \
 		--parameters \
 			"ParameterKey=AppName,ParameterValue=${APP}" \
 			"ParameterKey=AppStackName,ParameterValue=${PROJECT}-${ENV}-${NAME_SUFFIX}-app-${APP}" \
@@ -93,7 +94,7 @@ create-app: upload-app
 			"ParameterKey=ContainerPort,ParameterValue=8080" \
 			"ParameterKey=Environment,ParameterValue=${ENV}" \
 			"ParameterKey=FoundationStackName,ParameterValue=${PROJECT}-${ENV}-${NAME_SUFFIX}-foundation" \
-			"ParameterKey=InfraDevBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.infradev" \
+			"ParameterKey=InfraDevBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev" \
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomain,ParameterValue=${SUBDOMAIN}.${DOMAIN}" \
 			"ParameterKey=PublicFQDN,ParameterValue=${APP}.${SUBDOMAIN}.${DOMAIN}" \
@@ -140,7 +141,7 @@ update-foundation: upload
 		--parameters \
 			"ParameterKey=CidrBlock,ParameterValue=10.1.0.0/16" \
 			"ParameterKey=Environment,ParameterValue=${ENV}" \
-			"ParameterKey=FoundationBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.foundation" \
+			"ParameterKey=FoundationBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation" \
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomain,ParameterValue=${DOMAIN}" \
 			"ParameterKey=PublicFQDN,ParameterValue=${SUBDOMAIN}.${DOMAIN}" \
@@ -168,7 +169,7 @@ update-app: upload-app
 			"ParameterKey=ContainerPort,ParameterValue=8080" \
 			"ParameterKey=Environment,ParameterValue=${ENV}" \
 			"ParameterKey=FoundationStackName,ParameterValue=${PROJECT}-${ENV}-${NAME_SUFFIX}-foundation" \
-			"ParameterKey=InfraDevBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.infradev" \
+			"ParameterKey=InfraDevBucket,ParameterValue=awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev" \
 			"ParameterKey=ProjectName,ParameterValue=${PROJECT}" \
 			"ParameterKey=PublicDomain,ParameterValue=${SUBDOMAIN}.${DOMAIN}" \
 			"ParameterKey=PublicFQDN,ParameterValue=${APP}.${SUBDOMAIN}.${DOMAIN}" \
@@ -260,31 +261,31 @@ upload-pipeline: upload-all-envs
 
 ## Upload CF Templates to S3
 # Uploads foundation templates to the Foundation bucket
-# awsrig.${PROJECT}.${NAME_SUFFIX}.foundation/${ENV}/templates/
+# awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation/${ENV}/templates/
 upload:
-	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.foundation/${ENV}/templates/
+	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation/${ENV}/templates/
 
 
 ## Upload CF Templates to S3
 # Uploads foundation templates to the Foundation bucket
 # awsrig.${PROJECT}.${NAME_SUFFIX}.foundation/${ENV}/templates/
 upload-all-envs:
-	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.foundation/dev/templates/
-	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.foundation/stg/templates/
-	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.foundation/prd/templates/
+	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation/dev/templates/
+	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation/stg/templates/
+	@aws s3 cp --recursive aws/foundation/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation/prd/templates/
 
 
 ## Upload CF Templates for APP
 # Note that these templates will be stored in your InfraDev Project **shared** bucket:
-# awsrig.${PROJECT}.${NAME_SUFFIX}.infradev/${ENV}/templates/
+# awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev/${ENV}/templates/
 upload-app:
-	@aws s3 cp --recursive aws/app/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.infradev/${ENV}/templates/
+	@aws s3 cp --recursive aws/app/ s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev/${ENV}/templates/
 	pwd=$(shell pwd)
 	cd aws/app/ && zip templates.zip *.yaml
 	cd ${pwd}
-	@aws s3 cp aws/app/templates.zip s3://awsrig.${PROJECT}.${NAME_SUFFIX}.infradev/${PROJECT}-${ENV}-${NAME_SUFFIX}-app-${APP}/templates/
+	@aws s3 cp aws/app/templates.zip s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev/${PROJECT}-${ENV}-${NAME_SUFFIX}-app-${APP}/templates/
 	rm -rf aws/app/templates.zip
-	@aws s3 cp aws/app/service.yaml s3://awsrig.${PROJECT}.${NAME_SUFFIX}.infradev/${PROJECT}-${ENV}-${NAME_SUFFIX}-app-${APP}/templates/
+	@aws s3 cp aws/app/service.yaml s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev/${PROJECT}-${ENV}-${NAME_SUFFIX}-app-${APP}/templates/
 
 
 store-ubuntu-ami:

--- a/aws/app/deployment-pipeline.yaml
+++ b/aws/app/deployment-pipeline.yaml
@@ -41,17 +41,28 @@ Parameters:
     Description: The name of the branch for the CodeCommit repo
     Type: String
 
+  RepositoryAuthToken:
+    Description: The OAuth token required to obtain sources from your repo.
+    Type: String
+    NoEcho: true
+
   TargetGroup:
     Type: String
 
 Resources:
   Repository:
     Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+    # Hate to do this, but this *will* cause stack-deletion errors if the repo
+    # has any images in it, which any self-respecting repo will have.
     Properties:
       RepositoryName: !Join [ '-', [ !Ref AppStackName, 'ecr', 'repo' ] ]
 
   CloudFormationExecutionRole:
     Type: AWS::IAM::Role
+    # Hate to do this, but if stack deletion fails after this role has been deleted
+    # then you'll never be able to complete deletion of the service stack.
+    DeletionPolicy: Retain
     Properties:
       Path: /
       AssumeRolePolicyDocument: |
@@ -115,6 +126,11 @@ Resources:
                   - ecr:InitiateLayerUpload
                   - ecr:UploadLayerPart
                   - ecr:CompleteLayerUpload
+              # TODO:  this needs to be tightened-up.
+              - Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+                Effect: Allow
+                Action:
+                  - ssm:GetParameters
 
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
@@ -182,22 +198,6 @@ Resources:
       Source:
         Location: !Sub ${BuildArtifactsBucket}/${AppStackName}.zip
         Type: "S3"
-        BuildSpec: |
-          version: 0.2
-          phases:
-            pre_build:
-              commands:
-                - $(aws ecr get-login)
-                - TAG="$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"
-            build:
-              commands:
-                - docker build --tag "${REPOSITORY_URI}:${TAG}" .
-            post_build:
-              commands:
-                - docker push "${REPOSITORY_URI}:${TAG}"
-                - printf '{"tag":"%s"}' $TAG > build.json
-          artifacts:
-            files: build.json
       Environment:
         ComputeType: "BUILD_GENERAL1_SMALL"
         Image: "aws/codebuild/docker:1.12.1"
@@ -223,15 +223,17 @@ Resources:
             - Name: App
               ActionTypeId:
                 Category: Source
-                Owner: AWS
+                Owner: ThirdParty
                 Version: 1
-                Provider: CodeCommit
+                Provider: GitHub
+              Configuration:
+                Repo: !Ref RepositoryName
+                Branch: !Ref RepositoryBranch
+                Owner: buildit
+                OAuthToken: !Ref RepositoryAuthToken
               OutputArtifacts:
                 - Name: App
               RunOrder: 1
-              Configuration:
-                BranchName: !Ref RepositoryBranch
-                RepositoryName: !Ref RepositoryName
             - Name: Template
               ActionTypeId:
                 Category: Source

--- a/aws/app/ecs-cluster.yaml
+++ b/aws/app/ecs-cluster.yaml
@@ -175,6 +175,7 @@ Resources:
     Properties:
       ImageId: !FindInMap [ AWSRegionToAMI, !Ref "AWS::Region", AMI ]
       InstanceType: !Ref InstanceType
+      KeyName: !Ref SshKeyName
       IamInstanceProfile: !Ref InstanceProfile
       KeyName: !Ref SshKeyName
       SecurityGroups:

--- a/aws/app/ecs-cluster.yaml
+++ b/aws/app/ecs-cluster.yaml
@@ -48,7 +48,10 @@ Parameters:
     Description: Foundation stack name
     Type: String
 
-  SourceSecurityGroup:
+  ServerSourceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup::Id
+
+  WebSourceSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
 
   SshKeyName:
@@ -107,7 +110,9 @@ Resources:
     Properties:
       GroupDescription: !Sub ${AWS::StackName}-hosts
       SecurityGroupIngress:
-        - SourceSecurityGroupId: !Ref SourceSecurityGroup
+        - SourceSecurityGroupId: !Ref ServerSourceSecurityGroup
+          IpProtocol: -1
+        - SourceSecurityGroupId: !Ref WebSourceSecurityGroup
           IpProtocol: -1
       VpcId:
         Fn::ImportValue: !Sub "${FoundationStackName}--VpcId"

--- a/aws/app/load-balancer.yaml
+++ b/aws/app/load-balancer.yaml
@@ -28,8 +28,8 @@ Resources:
       SecurityGroupIngress:
         - CidrIp: "0.0.0.0/0"
           IpProtocol: "TCP"
-          FromPort: 80
-          ToPort: 80
+          FromPort: 443
+          ToPort: 443
       VpcId:
         Fn::ImportValue: !Sub "${FoundationStackName}--VpcId"
 
@@ -59,8 +59,8 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
-      Port: 80
-      Protocol: HTTP
+      Port: 443
+      Protocol: HTTPS
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup

--- a/aws/app/load-balancer.yaml
+++ b/aws/app/load-balancer.yaml
@@ -71,7 +71,7 @@ Resources:
     Properties:
       VpcId:
         Fn::ImportValue: !Sub "${FoundationStackName}--VpcId"
-      Port: 80
+      Port: 8888
       Protocol: HTTP
       Matcher:
         HttpCode: 200-299,401,403
@@ -97,6 +97,17 @@ Resources:
         - TargetGroupArn: !Ref TargetGroup
           Type: forward
 
+  elbDNS:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      HostedZoneName: !Sub "${DnsHostedZoneName}."
+      Comment: DNS for ELB.
+      RecordSets:
+      - Name: !Sub "${DnsSubdomainName}.${DnsHostedZoneName}."
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
+          DNSName: !GetAtt LoadBalancer.DNSName
 
 Outputs:
   TargetGroup:

--- a/aws/app/main.yaml
+++ b/aws/app/main.yaml
@@ -69,6 +69,27 @@ Parameters:
     Description: User FirstLastName
     Type: String
 
+  PublicDomainName:
+    Description: Public Domain Name for sites and services created by this stack.
+    Type: String
+
+  BuildUserAccessKeySerial:
+    Description: Increment this value by one to rotate the build user key.
+    Type: Number
+    Default: 0
+
+  ParameterStoreNamespace:
+    Description: Namespace in parameter store from which configuration values will be taken.
+    Type: String
+
+  ServerRepository:
+    Description: Cluster repository name for bookit server
+    Type: String
+
+  WebRepository:
+    Description: Cluster repository name for bookit web
+    Type: String
+
 Resources:
   CodeCommitRepo:
     Type: AWS::CodeCommit::Repository
@@ -76,22 +97,23 @@ Resources:
       RepositoryName: !Join [ '-', [ !Ref ProjectName, !Ref UserName, !Ref AppName ] ]
       RepositoryDescription: !Sub "Project repository for ${ProjectName}"
 
-  LoadBalancer:
+  ServerLoadBalancer:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/${Environment}/templates/load-balancer.yaml
+      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/templates/load-balancer.yaml
       Parameters:
-        AppStackName: !Ref AppStackName
+        AppStackName: !Sub ${AppStackName}-server
         FoundationStackName: !Ref FoundationStackName
         PublicDomain: !Ref PublicDomain
         PublicFQDN: !Ref PublicFQDN
 
   Cluster:
     DependsOn:
-      - LoadBalancer
+      - ServerLoadBalancer
+      - WebLoadBalancer
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/${Environment}/templates/ecs-cluster.yaml
+      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/templates/ecs-cluster.yaml
       Parameters:
         AppStackName: !Ref AppStackName
         FoundationStackName: !Ref FoundationStackName
@@ -103,7 +125,7 @@ Resources:
       - Cluster
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/${Environment}/templates/service.yaml
+      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/templates/service.yaml
       Parameters:
         AppName: !Ref AppName
         AppStackName: !Ref AppStackName
@@ -119,6 +141,10 @@ Resources:
 
 Outputs:
 
-  LoadBalancerUrl:
+  ServerLoadBalancerUrl:
     Description: URL of the load balancer for the sample service.
-    Value: !GetAtt LoadBalancer.Outputs.ServiceUrl
+    Value: !GetAtt ServerLoadBalancer.Outputs.ServiceUrl
+
+  WebLoadBalancerUrl:
+    Description: URL of the load balancer for the sample service.
+    Value: !GetAtt WebLoadBalancer.Outputs.ServiceUrl

--- a/aws/app/main.yaml
+++ b/aws/app/main.yaml
@@ -28,6 +28,10 @@ Parameters:
     Description: Stack environment
     Type: String
 
+  EcsClusterSize:
+    Type: Number
+    Default: 1
+
   FoundationStackName:
     Description: Foundation stack name
     Type: String
@@ -94,13 +98,12 @@ Resources:
         SourceSecurityGroup: !GetAtt LoadBalancer.Outputs.SecurityGroup
         SshKeyName: !Ref SshKeyName
 
-  DeploymentPipeline:
+  BookitServerService:
     DependsOn:
       - Cluster
-      - LoadBalancer
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/${Environment}/templates/deployment-pipeline.yaml
+      TemplateURL: !Sub https://s3.amazonaws.com/${InfraDevBucket}/${Environment}/templates/service.yaml
       Parameters:
         AppName: !Ref AppName
         AppStackName: !Ref AppStackName
@@ -112,19 +115,9 @@ Resources:
         RepositoryName: !GetAtt CodeCommitRepo.Name
         RepositoryBranch: !Ref RepositoryBranch
         TargetGroup: !GetAtt LoadBalancer.Outputs.TargetGroup
+        Repository: !Ref Repository
 
 Outputs:
-  CodeCommitRepoArn:
-    Description: Created Code Commit Repo Arn
-    Export:
-      Name: !Sub "${AppStackName}--CodeCommitRepoArn"
-    Value: !GetAtt CodeCommitRepo.Arn
-
-  CodeCommitRepoName:
-    Description: Created Code Commit Repo Name
-    Export:
-      Name: !Sub "${AppStackName}--CodeCommitRepoName"
-    Value: !GetAtt CodeCommitRepo.Name
 
   LoadBalancerUrl:
     Description: URL of the load balancer for the sample service.

--- a/aws/app/service.yaml
+++ b/aws/app/service.yaml
@@ -36,6 +36,9 @@ Parameters:
   TargetGroup:
     Type: String
 
+  ContainerPort:
+    Type: Number
+
 Resources:
   ECSServiceRole:
     Type: AWS::IAM::Role

--- a/aws/app/service.yaml
+++ b/aws/app/service.yaml
@@ -36,8 +36,15 @@ Parameters:
   TargetGroup:
     Type: String
 
+  BookitApiDomainName:
+    Type: String
+    Default: example.com
+
   ContainerPort:
     Type: Number
+
+  ParameterStoreNamespace:
+    Type: String
 
 Resources:
   ECSServiceRole:

--- a/bin/build-dotmake.sh
+++ b/bin/build-dotmake.sh
@@ -14,6 +14,9 @@ read -p 'AWS SSH keyname: ' keyname
 read -p 'Your name suffix (firstlastname): ' name_suffix
 read -p 'AWS Profile: ' profile
 read -p 'Project: ' project
+read -p 'Repository Name: ' repo
+read -p 'Repository Branch: ' repo_branch
+read -p 'Repository OAuth token: ' repo_token
 read -p 'AWS region: ' region
 read -p 'Subdomain: ' subdomain
 echo
@@ -31,6 +34,9 @@ KEY_NAME = ${keyname}
 NAME_SUFFIX = ${name_suffix}
 PROFILE = ${profile}
 PROJECT = ${project}
+REPO = ${repo}
+REPO_BRANCH = ${repo_branch}
+REPO_TOKEN = ${repo_token}
 REGION = ${region}
 SUBDOMAIN = ${subdomain}
 EOF

--- a/bin/create-buckets.sh
+++ b/bin/create-buckets.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-echo "Create Foundation S3 bucket: awsrig.${PROJECT}.${NAME_SUFFIX}.foundation"
-aws s3api head-bucket --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.foundation" --region "${REGION}" 2> /dev/null ||
-  aws s3 mb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.foundation  --region "${REGION}" # Foundation configs
-aws s3api put-bucket-versioning --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.foundation" --versioning-configuration Status=Enabled --region "${REGION}"
+echo "Create Foundation S3 bucket: awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation"
+aws s3api head-bucket --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation" --region "${REGION}" 2> /dev/null ||
+  aws s3 mb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation  --region "${REGION}" # Foundation configs
+aws s3api put-bucket-versioning --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation" --versioning-configuration Status=Enabled --region "${REGION}"
 
-echo "Create InfraDev S3 bucket: awsrig.${PROJECT}.${NAME_SUFFIX}.infradev"
-aws s3api head-bucket --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.infradev" --region "${REGION}" 2> /dev/null ||
-  aws s3 mb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.infradev --region "${REGION}" # Storage for InfraDev
-aws s3api put-bucket-versioning --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.infradev" --versioning-configuration Status=Enabled --region "${REGION}"
+echo "Create InfraDev S3 bucket: awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev"
+aws s3api head-bucket --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev" --region "${REGION}" 2> /dev/null ||
+  aws s3 mb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev --region "${REGION}" # Storage for InfraDev
+aws s3api put-bucket-versioning --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev" --versioning-configuration Status=Enabled --region "${REGION}"
 
-echo "Create Build Artifacts S3 bucket: awsrig.${PROJECT}.${NAME_SUFFIX}.build"
-aws s3api head-bucket --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.build" --region "${REGION}" 2> /dev/null ||
-  aws s3 mb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.build --region "${REGION}" # Build artifacts, etc
-aws s3api put-bucket-versioning --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.build" --versioning-configuration Status=Enabled --region "${REGION}"
+echo "Create Build Artifacts S3 bucket: awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.build"
+aws s3api head-bucket --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.build" --region "${REGION}" 2> /dev/null ||
+  aws s3 mb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.build --region "${REGION}" # Build artifacts, etc
+aws s3api put-bucket-versioning --bucket "awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.build" --versioning-configuration Status=Enabled --region "${REGION}"

--- a/bin/destroy-deps.sh
+++ b/bin/destroy-deps.sh
@@ -7,6 +7,6 @@ echo 'This script will remove the (empty only) S3 dependency buckets...'
 : ${NAME_SUFFIX?"Need to set name suffix in NAME_SUFFIX env var"}
 
 # Create confirmation etc:
-aws s3 rb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.foundation
-aws s3 rb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.infradev
-aws s3 rb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.build
+aws s3 rb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.foundation
+aws s3 rb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.infradev
+aws s3 rb s3://awsrig.${PROJECT}.${NAME_SUFFIX}.${REGION}.build


### PR DESCRIPTION
### Likely won't merge this, but wanted to distill and comment on the changes to be brought into the develop branch.


Initial changes for bookit-specific build.
Bunch of related changes I made while trying to get ECS to build/run bookit-server, taking into account the SSM parameter store as a source for secrets.
- Appropriate task definition.  Note that it runs special run-in-aws.sh bookit-server start script.
- IAM roles assigned
- Get Task/Service/ELB ports assigned properly (or at least working)
- A number of configuration changes to allow more flexibility, which was needed during my many test runs.

Pass in repository stuff via top-level parameters.
Keep bucket names unique.  Using region in the name seems a little goofy, but it's an easy way to get the uniqueness.
Hack to prevent issue that happened due to a non-atomic failed deletion in Cfn that resulted in a hung stack that couldn't be deleted due to a deleted role.
Don't try to delete the repo associated with the stack -- it will probably have images in it and will fail deletion.
Stop using deployment-pipeline.yml (don't want to use CodePipeline/CodeBuild at this point).  Thus, pull repo "local", and create Service stack directly (with desired count of '0' to start).
Add simplest-possible DNS record creation.
Put ECS instances in private subnet.
Surface ECS cluster size.
Rename bucket prefix to awsrig
Expect S3 bucket creation to fail
Avoid seeing error on multiple executions